### PR TITLE
Use Long type for count

### DIFF
--- a/avro2tf/src/main/scala/com/linkedin/avro2tf/jobs/FeatureListGeneration.scala
+++ b/avro2tf/src/main/scala/com/linkedin/avro2tf/jobs/FeatureListGeneration.scala
@@ -211,7 +211,7 @@ class FeatureListGeneration {
    */
   private def writeFeatureEntriesWCountToDisk(
     p: Path,
-    featureEntriesWCount: Seq[(String, Int)],
+    featureEntriesWCount: Seq[(String, Long)],
     prefix: Option[String],
     fileSystem: FileSystem): Unit = {
 
@@ -278,7 +278,7 @@ class FeatureListGeneration {
     tensorGroups.foreach( // each element is an array containing the output tensor names sharing one feature list
       tensors => {
         // for the current group of tensors sharing one feature list, accumulate feature entry count in a hashmap
-        val featureEntriesWCount = new mutable.HashMap[String, Int]().withDefaultValue(0)
+        val featureEntriesWCount = new mutable.HashMap[String, Long]().withDefaultValue(0L)
         // get a list of tensors where a prefix needs to be removed when accumulating feature entry count and added back
         // when writing the feature entries out. These are ntv tensors with feature sharing setting
         val tensorsWithPrefix = new mutable.HashMap[String, String]()
@@ -319,7 +319,7 @@ class FeatureListGeneration {
                     else {
                       lineWithoutCount
                     }
-                    val count = line.split(SEPARATOR_FEATURE_COUNT).last.toInt
+                    val count = line.split(SEPARATOR_FEATURE_COUNT).last.toLong
                     featureEntriesWCount(featureEntry) += count
                   })
               fileInputStream.close()


### PR DESCRIPTION
This is to fix the stack trace below:

diagnostics: User class threw exception: java.lang.NumberFormatException: For input string: "4270058247"
01-08-2019 15:29:27 PDT tensorflow-content-click_avro2tf_avro2tfForTraining INFO - 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
01-08-2019 15:29:27 PDT tensorflow-content-click_avro2tf_avro2tfForTraining INFO - 	at java.lang.Integer.parseInt(Integer.java:583)
01-08-2019 15:29:27 PDT tensorflow-content-click_avro2tf_avro2tfForTraining INFO - 	at java.lang.Integer.parseInt(Integer.java:615)
01-08-2019 15:29:27 PDT tensorflow-content-click_avro2tf_avro2tfForTraining INFO - 	at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:272)
01-08-2019 15:29:27 PDT tensorflow-content-click_avro2tf_avro2tfForTraining INFO - 	at scala.collection.immutable.StringOps.toInt(StringOps.scala:29)
01-08-2019 15:29:27 PDT tensorflow-content-click_avro2tf_avro2tfForTraining INFO - 	at com.linkedin.avro2tf.jobs.FeatureListGeneration$$anonfun$writeFeatureList$1$$anonfun$apply$4$$anonfun$apply$5.apply(FeatureListGeneration.scala:322)