### PR TITLE
Fix the metadata write out bug if it is a subfolder of data output path

### DIFF
--- a/avro2tf/src/main/scala/com/linkedin/avro2tf/jobs/PrepRankingData.scala
+++ b/avro2tf/src/main/scala/com/linkedin/avro2tf/jobs/PrepRankingData.scala
@@ -130,15 +130,15 @@ object PrepRankingData {
       transformDf = transformDf.withColumn(it, flattenSparseVectorArray(col(it)))
     }
 
-    // update tensor_metadata.json
-    if (params.executionMode == TrainingMode.training) {
-      updateMetadata(spark, params, contentFeatures, transformDf, metadata)
-    }
-
     // write to disk
     val repartitionDf = TensorizeInJobHelper
       .repartitionData(transformDf, params.numOutputFiles, params.enableShuffle)
     repartitionDf.write.mode(SaveMode.Overwrite).avro(params.outputDataPath)
+
+    // update tensor_metadata.json, need to happen after above avro data write
+    if (params.executionMode == TrainingMode.training) {
+      updateMetadata(spark, params, contentFeatures, transformDf, metadata)
+    }
   }
 
   /**


### PR DESCRIPTION
Previously if the metadata output path is a sub-folder of the data output path, the metadata write out will be overwritten since it happen before the data overwrite. Simply swap the sequence will solve the bug.