### PR TITLE
Add skipPadding option in PrepRankingData job

### DIFF
--- a/avro2tf/src/main/scala/com/linkedin/avro2tf/constants/PrepRankingJobParamNames.scala
+++ b/avro2tf/src/main/scala/com/linkedin/avro2tf/constants/PrepRankingJobParamNames.scala
@@ -17,4 +17,5 @@ object PrepRankingJobParamNames {
   final val EXECUTION_MODE = "execution-mode"
   final val LABEL_PADDING_VALUE = "label-padding-value"
   final val FEATURE_PADDING_VALUE = "feature-padding-value"
+  final val SKIP_PADDING = "skip-padding"
 }

--- a/avro2tf/src/main/scala/com/linkedin/avro2tf/jobs/PrepRankingData.scala
+++ b/avro2tf/src/main/scala/com/linkedin/avro2tf/jobs/PrepRankingData.scala
@@ -121,7 +121,8 @@ object PrepRankingData {
             params.groupListMaxSize,
             isLabel,
             params.labelPaddingValue,
-            params.featurePaddingValue)(col(it)))
+            params.featurePaddingValue,
+            params.skipPadding)(col(it)))
     }
 
     // flatten indices of sparse tensors
@@ -212,20 +213,22 @@ object PrepRankingData {
    * @param isLabel Whether the column is a label field
    * @param labelPaddingValue The label padding value
    * @param featurePaddingValue The feature padding value
+   * @param skipPadding Skip padding for firstN if batch size is smaller than N
    * @return The udf does the taking first n items from array in a column
    */
   private def takeFirstN(
     dtype: ADataType,
     groupListMaxSize: Int,
-    isLabel: Boolean = false,
-    labelPaddingValue: Double = -1.0d,
-    featurePaddingValue: Double = 0.0d) = {
+    isLabel: Boolean,
+    labelPaddingValue: Double,
+    featurePaddingValue: Double,
+    skipPadding: Boolean) = {
 
     def takeFunc[T](paddingValue: T) = (array: Seq[T]) => {
       val filledArray = if (array.size >= groupListMaxSize) {
         array
       } else {
-        array ++ Seq.fill(groupListMaxSize - array.size)(paddingValue)
+        if (skipPadding) array else array ++ Seq.fill(groupListMaxSize - array.size)(paddingValue)
       }
       filledArray.take(groupListMaxSize)
     }

--- a/avro2tf/src/main/scala/com/linkedin/avro2tf/parsers/PrepRankingDataParamsParser.scala
+++ b/avro2tf/src/main/scala/com/linkedin/avro2tf/parsers/PrepRankingDataParamsParser.scala
@@ -16,7 +16,8 @@ case class PrepRankingDataParams(
   numOutputFiles: Int = -1,
   enableShuffle: Boolean = false,
   labelPaddingValue: Double = -1.0d,
-  featurePaddingValue: Double = 0.0d
+  featurePaddingValue: Double = 0.0d,
+  skipPadding: Boolean = false
 )
 
 object PrepRankingDataParamsParser {
@@ -145,6 +146,17 @@ object PrepRankingDataParamsParser {
         """Optional.
           |Padding values for scalar features. Default is 0.0d.
           |Not applicable for name-term-value features.
+        """.stripMargin
+      )
+
+    opt[Boolean](PrepRankingJobParamNames.SKIP_PADDING)
+      .action((x, p) => p.copy(skipPadding = x))
+      .optional()
+      .text(
+        """Optional.
+          |Skip padding option if it's set as true.
+          |If padding is skipped, padding is skipped for disk output and user will need to pad it in memory after loading it back
+          |The default value is false, which means padding is by default enabled
         """.stripMargin
       )
   }

--- a/avro2tf/src/test/resources/metadata/tensor_metadata_movielens_rank.json
+++ b/avro2tf/src/test/resources/metadata/tensor_metadata_movielens_rank.json
@@ -13,7 +13,7 @@
       "name" : "movieIdString",
       "dtype" : "string",
       "shape" : [
-        2
+        10
       ],
       "numUniqueValues" : null,
       "isSparse" : false,
@@ -23,7 +23,7 @@
       "name" : "genreFeaturesTerms",
       "dtype" : "string",
       "shape" : [
-        2,
+        10,
         10
       ],
       "numUniqueValues" : null,
@@ -34,7 +34,7 @@
       "name" : "movieId_hashed",
       "dtype" : "int",
       "shape" : [
-        2,
+        10,
         4
       ],
       "numUniqueValues" : 1000,
@@ -45,7 +45,7 @@
       "name" : "genreFeatures",
       "dtype" : "float",
       "shape" : [
-        2,
+        10,
         20
       ],
       "numUniqueValues" : null,
@@ -56,7 +56,7 @@
       "name" : "genreFeatures_movieLatentFactorFeatures",
       "dtype" : "float",
       "shape" : [
-        2,
+        10,
         100
       ],
       "numUniqueValues" : null,
@@ -69,7 +69,7 @@
       "name" : "response",
       "dtype" : "double",
       "shape" : [
-        2
+        10
       ],
       "numUniqueValues" : null,
       "isSparse" : false,

--- a/avro2tf/src/test/scala/com/linkedin/avro2tf/jobs/PrepRankingDataTest.scala
+++ b/avro2tf/src/test/scala/com/linkedin/avro2tf/jobs/PrepRankingDataTest.scala
@@ -10,10 +10,7 @@ import com.linkedin.avro2tf.utils.TestUtil.removeWhiteSpace
 import org.testng.annotations.Test
 import com.linkedin.avro2tf.utils.{IOUtils, TestUtil, WithLocalSparkSession}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.testng.Assert._
-
-import scala.collection.mutable
 
 class PrepRankingDataTest extends WithLocalSparkSession {
 
@@ -120,6 +117,6 @@ class PrepRankingDataTest extends WithLocalSparkSession {
 
     val df = IOUtils.readAvro(session, params.outputDataPath)
     // verify padding is skipped
-    assertTrue(df.select("response").collect().exists(row => row.asInstanceOf[GenericRowWithSchema].get(0).asInstanceOf[mutable.WrappedArray[Float]].size < 10))
+    assertTrue(df.select("response").collect().exists(row => row.getAs[Seq[Float]](0).size < 10))
   }
 }

--- a/avro2tf/src/test/scala/com/linkedin/avro2tf/jobs/PrepRankingDataTest.scala
+++ b/avro2tf/src/test/scala/com/linkedin/avro2tf/jobs/PrepRankingDataTest.scala
@@ -3,15 +3,17 @@ package com.linkedin.avro2tf.jobs
 import java.io.File
 
 import scala.io.Source
-
 import com.linkedin.avro2tf.constants.{Avro2TFJobParamNames, Constants, PrepRankingJobParamNames}
 import com.linkedin.avro2tf.parsers.{Avro2TFJobParamsParser, PrepRankingDataParamsParser}
 import com.linkedin.avro2tf.utils.ConstantsForTest._
 import com.linkedin.avro2tf.utils.TestUtil.removeWhiteSpace
 import org.testng.annotations.Test
-import com.linkedin.avro2tf.utils.{TestUtil, WithLocalSparkSession}
+import com.linkedin.avro2tf.utils.{IOUtils, TestUtil, WithLocalSparkSession}
 import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.testng.Assert._
+
+import scala.collection.mutable
 
 class PrepRankingDataTest extends WithLocalSparkSession {
 
@@ -44,7 +46,7 @@ class PrepRankingDataTest extends WithLocalSparkSession {
       PrepRankingJobParamNames.OUTPUT_DATA_PATH -> dataOutputPath,
       PrepRankingJobParamNames.OUTPUT_METADATA_PATH -> metadataOutputPath,
       PrepRankingJobParamNames.GROUP_ID_LIST -> "userId",
-      PrepRankingJobParamNames.GROUP_LIST_MAX_SIZE -> 2,
+      PrepRankingJobParamNames.GROUP_LIST_MAX_SIZE -> 10,
       PrepRankingJobParamNames.EXECUTION_MODE -> "training",
       PrepRankingJobParamNames.NUM_OUTPUT_FILES -> 1
     )
@@ -62,5 +64,62 @@ class PrepRankingDataTest extends WithLocalSparkSession {
       removeWhiteSpace(Source.fromFile(outputMetadataFile).mkString),
       removeWhiteSpace(Source.fromFile(expectedTensorMetadata).mkString)
     )
+  }
+
+  /**
+    * A unit test to test with skip padding, the output data should not pad and the generated metadata should be the same
+    */
+  @Test
+  def testPrepRankingDataWithSkipPadding(): Unit = {
+
+    val workingDir = WORKING_DIRECTORY_AVRO2TF_MOVIELENS
+    val avro2TFConfig = new File(
+      getClass.getClassLoader.getResource(AVRO2TF_CONFIG_PATH_VALUE_MOVIELENS_RANK).getFile
+    ).getAbsolutePath
+    FileUtils.deleteDirectory(new File(workingDir))
+
+    val inputPath = INPUT_MOVIELENS_FILE_PATHS
+    val trainingParams = Map(
+      Avro2TFJobParamNames.INPUT_PATHS -> inputPath,
+      Avro2TFJobParamNames.WORKING_DIR -> workingDir,
+      Avro2TFJobParamNames.AVRO2TF_CONFIG_PATH -> avro2TFConfig
+    )
+    val avro2TFTrainingParams = Avro2TFJobParamsParser.parse(TestUtil.convertParamMapToParamList(trainingParams))
+    Avro2TF.run(session, avro2TFTrainingParams)
+    assertTrue(new File(s"${avro2TFTrainingParams.workingDir.trainingDataPath}/_SUCCESS").exists())
+    assertTrue(new File(avro2TFTrainingParams.workingDir.tensorMetadataPath).exists())
+    assertTrue(new File(avro2TFTrainingParams.workingDir.featureListPath).exists())
+
+    val dataOutputPath = s"$workingDir/rankingOutput"
+    val metadataOutputPath = s"$workingDir/rankingMetadataOutput"
+    val prepRankingParams = Map(
+      PrepRankingJobParamNames.INPUT_DATA_PATH -> avro2TFTrainingParams.workingDir.trainingDataPath,
+      PrepRankingJobParamNames.INPUT_METADATA_PATH -> avro2TFTrainingParams.workingDir.tensorMetadataPath,
+      PrepRankingJobParamNames.OUTPUT_DATA_PATH -> dataOutputPath,
+      PrepRankingJobParamNames.OUTPUT_METADATA_PATH -> metadataOutputPath,
+      PrepRankingJobParamNames.GROUP_ID_LIST -> "userId",
+      PrepRankingJobParamNames.GROUP_LIST_MAX_SIZE -> 10,
+      PrepRankingJobParamNames.EXECUTION_MODE -> "training",
+      PrepRankingJobParamNames.NUM_OUTPUT_FILES -> 1,
+      PrepRankingJobParamNames.SKIP_PADDING -> "true"
+    )
+    val params = PrepRankingDataParamsParser.parse(TestUtil.convertParamMapToParamList(prepRankingParams))
+    PrepRankingData.run(session, params)
+
+    val outputMetadataFile = s"$metadataOutputPath/${Constants.TENSOR_METADATA_FILE_NAME}"
+    assertTrue(new File(s"$dataOutputPath/_SUCCESS").exists())
+    assertTrue(new File(outputMetadataFile).exists())
+    assertTrue(new File(s"$metadataOutputPath/${Constants.CONTENT_FEATURE_LIST}").exists())
+
+    // Check if tensor metadata JSON file is correctly generated
+    val expectedTensorMetadata = getClass.getClassLoader.getResource(EXPECTED_TENSOR_METADATA_MOVIELENS_RANK).getFile
+    assertEquals(
+      removeWhiteSpace(Source.fromFile(outputMetadataFile).mkString),
+      removeWhiteSpace(Source.fromFile(expectedTensorMetadata).mkString)
+    )
+
+    val df = IOUtils.readAvro(session, params.outputDataPath)
+    // verify padding is skipped
+    assertTrue(df.select("response").collect().exists(row => row.asInstanceOf[GenericRowWithSchema].get(0).asInstanceOf[mutable.WrappedArray[Float]].size < 10))
   }
 }


### PR DESCRIPTION
The skipPadding can help reduce size of file in disk. Later user can use python api to pad in memory, which is more efficient. Although the padding is skipped, the output metadata still keeps the groupList size as the first dimension